### PR TITLE
C++20 support, add static lib target, Skyrim support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ CMakeUserPresets.json
 
 # End of https://www.toptal.com/developers/gitignore/api/cmake
 
+.vs/
 .vscode/
 vcpkg_installed/
 vcpkg_installed/**

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,7 @@ CMakeUserPresets.json
 
 # End of https://www.toptal.com/developers/gitignore/api/cmake
 
+.vscode/
+vcpkg_installed/
+vcpkg_installed/**
 build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,18 +16,14 @@ project(${PACKAGE_NAME} CXX)
 
 if (VCPKG_TARGET_TRIPLET MATCHES "static")
   if(MSVC)
-    string(REPLACE "/MD" "/MT" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
-    string(REPLACE "/MD" "/MT" CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
-    string(REPLACE "/MD" "/MT" CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
-    string(REPLACE "/MD" "/MT" CMAKE_CXX_FLAGS_MINSIZEREL ${CMAKE_CXX_FLAGS_MINSIZEREL})
-    string(REPLACE "/MD" "/MT" CMAKE_CXX_FLAGS_RELWITHDEBINFO ${CMAKE_CXX_FLAGS_RELWITHDEBINFO})
+   # No longer necessary to replace flags
   else(MSVC)
     set(Boost_USE_STATIC_LIBS ON)
     set(Boost_USE_STATIC_RUNTIME ON)
   endif(MSVC)
 endif()
 
-find_package(Boost 1.73.0 REQUIRED COMPONENTS system program_options filesystem)
+find_package(Boost REQUIRED COMPONENTS system program_options filesystem)
 
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 cmake_policy(SET CMP0048 NEW)
-set(CMAKE_CXX_STANDARD 20)
 
 # package information
 set(PACKAGE_NAME      "Champollion")
@@ -16,13 +15,15 @@ endif()
 
 project(${PACKAGE_NAME} VERSION 1.0.8 LANGUAGES CXX)
 include(GNUInstallDirs)
-function (option_if_not_defined name description default)
-  if(NOT DEFINED ${name})
-      option(${name} ${description} ${default})
-  endif()
-endfunction()
 
-option_if_not_defined(CHAMPOLLION_STATIC_LIBRARY "Build Champollion as a standalone executable" OFF)
+
+option(CHAMPOLLION_STATIC_LIBRARY "Build Champollion as a static library" OFF)
+
+if (NOT CHAMPOLLION_STATIC_LIBRARY)
+  set(CMAKE_CXX_STANDARD 20)
+else()
+  set(CMAKE_CXX_STANDARD 17)
+endif()
 
 
 # Automatically create source_group directives for the sources passed in.
@@ -75,15 +76,17 @@ if(CHAMPOLLION_STATIC_LIBRARY)
   file(GLOB DECOMPILER_HEADER_FILES "Decompiler/*.hpp")
   file(GLOB PEX_HEADER_FILES "Pex/*.hpp")
   file(GLOB NODE_HEADER_FILES "Decompiler/Node/*.hpp")
+  list(APPEND ALL_HEADERS ${DECOMPILER_HEADER_FILES} ${PEX_HEADER_FILES} ${NODE_HEADER_FILES})
+
   file(GLOB SOURCE_FILES "Pex/*.cpp" "Decompiler/*.cpp" "Decompiler/Node/*.cpp")
 
-  add_library("${PROJECT_NAME}" STATIC ${SOURCE_FILES})
-  set_target_properties("${PROJECT_NAME}" PROPERTIES LINKER_LANGUAGE CXX)
+  add_library("${PROJECT_NAME}" STATIC ${ALL_HEADERS} ${SOURCE_FILES})
 
   target_include_directories(
     "${PROJECT_NAME}"
-    PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
+    PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CHAMPOLLION_INCLUDE_INSTALL_DIR}>
   )
   include(CMakePackageConfigHelpers)
   write_basic_package_version_file(
@@ -121,12 +124,10 @@ if(CHAMPOLLION_STATIC_LIBRARY)
   DESTINATION ${CHAMPOLLION_CONFIG_INSTALL_DIR})
 else()
   if (VCPKG_TARGET_TRIPLET MATCHES "static")
-    if(MSVC)
-     # No longer necessary to replace flags
-    else(MSVC)
+    if(NOT MSVC)
       set(Boost_USE_STATIC_LIBS ON)
       set(Boost_USE_STATIC_RUNTIME ON)
-    endif(MSVC)
+    endif()
   endif()
   find_package(Boost REQUIRED COMPONENTS program_options)
   include_directories(
@@ -136,4 +137,7 @@ else()
   add_subdirectory(Decompiler)
   add_subdirectory(Pex)
   add_subdirectory(Champollion)
+  install(
+    TARGETS Champollion
+  )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 cmake_policy(SET CMP0048 NEW)
+set(CMAKE_CXX_STANDARD 20)
 
 # package information
 set(PACKAGE_NAME      "Champollion")
@@ -23,16 +24,6 @@ endfunction()
 
 option_if_not_defined(CHAMPOLLION_STATIC_LIBRARY "Build Champollion as a standalone executable" OFF)
 
-if (VCPKG_TARGET_TRIPLET MATCHES "static")
-  if(MSVC)
-   # No longer necessary to replace flags
-  else(MSVC)
-    set(Boost_USE_STATIC_LIBS ON)
-    set(Boost_USE_STATIC_RUNTIME ON)
-  endif(MSVC)
-endif()
-
-find_package(Boost REQUIRED COMPONENTS system program_options filesystem)
 
 # Automatically create source_group directives for the sources passed in.
 function(auto_source_group rootName rootDir)
@@ -94,7 +85,6 @@ if(CHAMPOLLION_STATIC_LIBRARY)
     "${PROJECT_NAME}"
     PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
-    ${Boost_INCLUDE_DIRS}
   )
   include(CMakePackageConfigHelpers)
   write_basic_package_version_file(
@@ -131,6 +121,15 @@ if(CHAMPOLLION_STATIC_LIBRARY)
   install(FILES ${CHAMPOLLION_CMAKE_VERSION_CONFIG_FILE} ${CHAMPOLLION_CMAKE_PROJECT_CONFIG_FILE}
   DESTINATION ${CHAMPOLLION_CONFIG_INSTALL_DIR})
 else()
+  if (VCPKG_TARGET_TRIPLET MATCHES "static")
+    if(MSVC)
+     # No longer necessary to replace flags
+    else(MSVC)
+      set(Boost_USE_STATIC_LIBS ON)
+      set(Boost_USE_STATIC_RUNTIME ON)
+    endif(MSVC)
+  endif()
+  find_package(Boost REQUIRED COMPONENTS program_options)
   include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${Boost_INCLUDE_DIRS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_policy(SET CMP0048 NEW)
 
 # package information
 set(PACKAGE_NAME      "Champollion")
@@ -12,7 +13,15 @@ if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
       CACHE STRING "")
 endif()
 
-project(${PACKAGE_NAME} CXX)
+project(${PACKAGE_NAME} VERSION 1.46.0 LANGUAGES CXX)
+include(GNUInstallDirs)
+function (option_if_not_defined name description default)
+  if(NOT DEFINED ${name})
+      option(${name} ${description} ${default})
+  endif()
+endfunction()
+
+option_if_not_defined(CHAMPOLLION_STATIC_LIBRARY "Build Champollion as a standalone executable" OFF)
 
 if (VCPKG_TARGET_TRIPLET MATCHES "static")
   if(MSVC)
@@ -24,13 +33,6 @@ if (VCPKG_TARGET_TRIPLET MATCHES "static")
 endif()
 
 find_package(Boost REQUIRED COMPONENTS system program_options filesystem)
-
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${Boost_INCLUDE_DIRS}
-)
-
-add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 
 # Automatically create source_group directives for the sources passed in.
 function(auto_source_group rootName rootDir)
@@ -65,6 +67,75 @@ function(auto_source_group rootName rootDir)
   endforeach()
 endfunction()
 
-add_subdirectory(Decompiler)
-add_subdirectory(Pex)
-add_subdirectory(Champollion)
+
+add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+set(CHAMPOLLION_TARGET_NAME               ${PROJECT_NAME})
+set(CHAMPOLLION_CONFIG_INSTALL_DIR        "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}" CACHE INTERNAL "")
+set(CHAMPOLLION_INCLUDE_INSTALL_DIR       "${CMAKE_INSTALL_INCLUDEDIR}/Champollion")
+set(CHAMPOLLION_TARGETS_EXPORT_NAME       "${PROJECT_NAME}-targets")
+set(CHAMPOLLION_CMAKE_CONFIG_TEMPLATE     "cmake/Config.cmake.in")
+set(CHAMPOLLION_CMAKE_CONFIG_DIR          "${CMAKE_CURRENT_BINARY_DIR}")
+set(CHAMPOLLION_CMAKE_VERSION_CONFIG_FILE "${CHAMPOLLION_CMAKE_CONFIG_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
+set(CHAMPOLLION_CMAKE_PROJECT_CONFIG_FILE "${CHAMPOLLION_CMAKE_CONFIG_DIR}/${PROJECT_NAME}Config.cmake")
+set(CHAMPOLLION_CMAKE_PROJECT_TARGETS_FILE "${CHAMPOLLION_CMAKE_CONFIG_DIR}/${PROJECT_NAME}-targets.cmake")
+
+if(CHAMPOLLION_STATIC_LIBRARY)
+
+  file(GLOB DECOMPILER_HEADER_FILES "Decompiler/*.hpp")
+  file(GLOB PEX_HEADER_FILES "Pex/*.hpp")
+  file(GLOB NODE_HEADER_FILES "Decompiler/Node/*.hpp")
+  file(GLOB SOURCE_FILES "Pex/*.cpp" "Decompiler/*.cpp" "Decompiler/Node/*.cpp")
+
+  add_library("${PROJECT_NAME}" STATIC ${SOURCE_FILES})
+  set_target_properties("${PROJECT_NAME}" PROPERTIES LINKER_LANGUAGE CXX)
+  target_link_libraries("${PROJECT_NAME}" ${Boost_LIBRARIES})
+
+  target_include_directories(
+    "${PROJECT_NAME}"
+    PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${Boost_INCLUDE_DIRS}
+  )
+  include(CMakePackageConfigHelpers)
+  write_basic_package_version_file(
+      ${CHAMPOLLION_CMAKE_VERSION_CONFIG_FILE} COMPATIBILITY SameMajorVersion
+  )
+  configure_package_config_file(
+    ${CHAMPOLLION_CMAKE_CONFIG_TEMPLATE}
+    "${CHAMPOLLION_CMAKE_PROJECT_CONFIG_FILE}" 
+    INSTALL_DESTINATION ${CHAMPOLLION_CONFIG_INSTALL_DIR}
+  )
+
+  install(
+    TARGETS "${CHAMPOLLION_TARGET_NAME}"
+    EXPORT "${CHAMPOLLION_TARGETS_EXPORT_NAME}"
+  )
+
+  install(
+    EXPORT "${CHAMPOLLION_TARGETS_EXPORT_NAME}"
+    NAMESPACE "${CHAMPOLLION_TARGET_NAME}::"
+    DESTINATION "${CHAMPOLLION_CONFIG_INSTALL_DIR}"
+  )
+  install(
+    FILES ${DECOMPILER_HEADER_FILES}
+    DESTINATION "${CHAMPOLLION_INCLUDE_INSTALL_DIR}/Decompiler"
+  )
+  install(
+    FILES ${PEX_HEADER_FILES}
+    DESTINATION "${CHAMPOLLION_INCLUDE_INSTALL_DIR}/Pex"
+  )
+  install(
+    FILES ${NODE_HEADER_FILES}
+    DESTINATION "${CHAMPOLLION_INCLUDE_INSTALL_DIR}/Decompiler/Node"
+  )
+  install(FILES ${CHAMPOLLION_CMAKE_VERSION_CONFIG_FILE} ${CHAMPOLLION_CMAKE_PROJECT_CONFIG_FILE}
+  DESTINATION ${CHAMPOLLION_CONFIG_INSTALL_DIR})
+else()
+  include_directories(
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${Boost_INCLUDE_DIRS}
+  )
+  add_subdirectory(Decompiler)
+  add_subdirectory(Pex)
+  add_subdirectory(Champollion)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
       CACHE STRING "")
 endif()
 
-project(${PACKAGE_NAME} VERSION 1.46.0 LANGUAGES CXX)
+project(${PACKAGE_NAME} VERSION 1.0.8 LANGUAGES CXX)
 include(GNUInstallDirs)
 function (option_if_not_defined name description default)
   if(NOT DEFINED ${name})
@@ -79,7 +79,6 @@ if(CHAMPOLLION_STATIC_LIBRARY)
 
   add_library("${PROJECT_NAME}" STATIC ${SOURCE_FILES})
   set_target_properties("${PROJECT_NAME}" PROPERTIES LINKER_LANGUAGE CXX)
-  target_link_libraries("${PROJECT_NAME}" ${Boost_LIBRARIES})
 
   target_include_directories(
     "${PROJECT_NAME}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_policy(SET CMP0048 NEW)
 
 # package information
 set(PACKAGE_NAME      "Champollion")
-set(PACKAGE_VERSION   "1.0.8")
+set(PACKAGE_VERSION   "1.1.0")
 set(PACKAGE_STRING    "${PACKAGE_NAME} ${PACKAGE_VERSION}")
 set(PACKAGE_TARNAME   "${PACKAGE_NAME}-${PACKAGE_VERSION}")
 set(PACKAGE_BUGREPORT "https://github.com/Orvid/champollion/issues")
@@ -13,7 +13,7 @@ if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
       CACHE STRING "")
 endif()
 
-project(${PACKAGE_NAME} VERSION 1.0.8 LANGUAGES CXX)
+project(${PACKAGE_NAME} VERSION 1.1.0 LANGUAGES CXX)
 include(GNUInstallDirs)
 
 

--- a/Champollion/glob.hpp
+++ b/Champollion/glob.hpp
@@ -1,0 +1,443 @@
+/**************************************************************************
+ * MIT License
+ * 
+ * Copyright (c) 2019 Pranav
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * **************************************************************************
+*/
+#pragma once
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <regex>
+#include <string>
+#include <vector>
+
+#ifdef GLOB_USE_GHC_FILESYSTEM
+#include <ghc/filesystem.hpp>
+#else
+#include <filesystem>
+#endif
+
+namespace glob {
+
+#ifdef GLOB_USE_GHC_FILESYSTEM
+namespace fs = ghc::filesystem;
+#else
+namespace fs = std::filesystem;
+#endif
+
+namespace {
+
+static inline 
+bool string_replace(std::string &str, const std::string &from, const std::string &to) {
+  std::size_t start_pos = str.find(from);
+  if (start_pos == std::string::npos)
+    return false;
+  str.replace(start_pos, from.length(), to);
+  return true;
+}
+
+static inline 
+std::string translate(const std::string &pattern) {
+  std::size_t i = 0, n = pattern.size();
+  std::string result_string;
+
+  while (i < n) {
+    auto c = pattern[i];
+    i += 1;
+    if (c == '*') {
+      result_string += ".*";
+    } else if (c == '?') {
+      result_string += ".";
+    } else if (c == '[') {
+      auto j = i;
+      if (j < n && pattern[j] == '!') {
+        j += 1;
+      }
+      if (j < n && pattern[j] == ']') {
+        j += 1;
+      }
+      while (j < n && pattern[j] != ']') {
+        j += 1;
+      }
+      if (j >= n) {
+        result_string += "\\[";
+      } else {
+        auto stuff = std::string(pattern.begin() + i, pattern.begin() + j);
+        if (stuff.find("--") == std::string::npos) {
+          string_replace(stuff, std::string{"\\"}, std::string{R"(\\)"});
+        } else {
+          std::vector<std::string> chunks;
+          std::size_t k = 0;
+          if (pattern[i] == '!') {
+            k = i + 2;
+          } else {
+            k = i + 1;
+          }
+
+          while (true) {
+            k = pattern.find("-", k, j);
+            if (k == std::string::npos) {
+              break;
+            }
+            chunks.push_back(std::string(pattern.begin() + i, pattern.begin() + k));
+            i = k + 1;
+            k = k + 3;
+          }
+
+          chunks.push_back(std::string(pattern.begin() + i, pattern.begin() + j));
+          // Escape backslashes and hyphens for set difference (--).
+          // Hyphens that create ranges shouldn't be escaped.
+          bool first = false;
+          for (auto &s : chunks) {
+            string_replace(s, std::string{"\\"}, std::string{R"(\\)"});
+            string_replace(s, std::string{"-"}, std::string{R"(\-)"});
+            if (first) {
+              stuff += s;
+              first = false;
+            } else {
+              stuff += "-" + s;
+            }
+          }
+        }
+
+        // Escape set operations (&&, ~~ and ||).
+        std::string result;
+        std::regex_replace(std::back_inserter(result),          // result
+                           stuff.begin(), stuff.end(),          // string
+                           std::regex(std::string{R"([&~|])"}), // pattern
+                           std::string{R"(\\\1)"});             // repl
+        stuff = result;
+        i = j + 1;
+        if (stuff[0] == '!') {
+          stuff = "^" + std::string(stuff.begin() + 1, stuff.end());
+        } else if (stuff[0] == '^' || stuff[0] == '[') {
+          stuff = "\\\\" + stuff;
+        }
+        result_string = result_string + "[" + stuff + "]";
+      }
+    } else {
+      // SPECIAL_CHARS
+      // closing ')', '}' and ']'
+      // '-' (a range in character set)
+      // '&', '~', (extended character set operations)
+      // '#' (comment) and WHITESPACE (ignored) in verbose mode
+      static std::string special_characters = "()[]{}?*+-|^$\\.&~# \t\n\r\v\f";
+      static std::map<int, std::string> special_characters_map;
+      if (special_characters_map.empty()) {
+        for (auto &sc : special_characters) {
+          special_characters_map.insert(
+              std::make_pair(static_cast<int>(sc), std::string{"\\"} + std::string(1, sc)));
+        }
+      }
+
+      if (special_characters.find(c) != std::string::npos) {
+        result_string += special_characters_map[static_cast<int>(c)];
+      } else {
+        result_string += c;
+      }
+    }
+  }
+  return std::string{"(("} + result_string + std::string{R"()|[\r\n])$)"};
+}
+
+static inline 
+std::regex compile_pattern(const std::string &pattern) {
+  return std::regex(translate(pattern), std::regex::ECMAScript);
+}
+
+static inline 
+bool fnmatch(const fs::path &name, const std::string &pattern) {
+  return std::regex_match(name.string(), compile_pattern(pattern));
+}
+
+static inline 
+std::vector<fs::path> filter(const std::vector<fs::path> &names,
+                             const std::string &pattern) {
+  // std::cout << "Pattern: " << pattern << "\n";
+  std::vector<fs::path> result;
+  for (auto &name : names) {
+    // std::cout << "Checking for " << name.string() << "\n";
+    if (fnmatch(name, pattern)) {
+      result.push_back(name);
+    }
+  }
+  return result;
+}
+
+static inline 
+fs::path expand_tilde(fs::path path) {
+  if (path.empty()) return path;
+
+#ifdef _WIN32
+  const char * home_variable = "USERNAME";
+#else
+  const char * home_variable = "USER";
+#endif
+  const char * home = std::getenv(home_variable);
+  if (home == nullptr) {
+    throw std::invalid_argument("error: Unable to expand `~` - HOME environment variable not set.");
+  }
+
+  std::string s = path.string();
+  if (s[0] == '~') {
+    s = std::string(home) + s.substr(1, s.size() - 1);
+    return fs::path(s);
+  } else {
+    return path;
+  }
+}
+
+static inline 
+bool has_magic(const std::string &pathname) {
+  static const auto magic_check = std::regex("([*?[])");
+  return std::regex_search(pathname, magic_check);
+}
+
+static inline 
+bool is_hidden(const std::string &pathname) {
+  return std::regex_match(pathname, std::regex("^(.*\\/)*\\.[^\\.\\/]+\\/*$"));
+}
+
+static inline 
+bool is_recursive(const std::string &pattern) { return pattern == "**"; }
+
+static inline 
+std::vector<fs::path> iter_directory(const fs::path &dirname, bool dironly) {
+  std::vector<fs::path> result;
+
+  auto current_directory = dirname;
+  if (current_directory.empty()) {
+    current_directory = fs::current_path();
+  }
+
+  if (fs::exists(current_directory)) {
+    try {
+      for (auto &entry : fs::directory_iterator(
+              current_directory, fs::directory_options::follow_directory_symlink |
+                                      fs::directory_options::skip_permission_denied)) {
+        if (!dironly || entry.is_directory()) {
+          if (dirname.is_absolute()) {
+            result.push_back(entry.path());
+          } else {
+            result.push_back(fs::relative(entry.path()));
+          }
+        }
+      }
+    } catch (std::exception&) {
+      // not a directory
+      // do nothing
+    }
+  }
+
+  return result;
+}
+
+// Recursively yields relative pathnames inside a literal directory.
+static inline 
+std::vector<fs::path> rlistdir(const fs::path &dirname, bool dironly) {
+  std::vector<fs::path> result;
+  auto names = iter_directory(dirname, dironly);
+  for (auto &x : names) {
+    if (!is_hidden(x.string())) {
+      result.push_back(x);
+      for (auto &y : rlistdir(x, dironly)) {
+        result.push_back(y);
+      }
+    }
+  }
+  return result;
+}
+
+// This helper function recursively yields relative pathnames inside a literal
+// directory.
+static inline 
+std::vector<fs::path> glob2(const fs::path &dirname, [[maybe_unused]] const std::string &pattern,
+                            bool dironly) {
+  // std::cout << "In glob2\n";
+  std::vector<fs::path> result;
+  assert(is_recursive(pattern));
+  for (auto &dir : rlistdir(dirname, dironly)) {
+    result.push_back(dir);
+  }
+  return result;
+}
+
+// These 2 helper functions non-recursively glob inside a literal directory.
+// They return a list of basenames.  _glob1 accepts a pattern while _glob0
+// takes a literal basename (so it only has to check for its existence).
+static inline 
+std::vector<fs::path> glob1(const fs::path &dirname, const std::string &pattern,
+                            bool dironly) {
+  // std::cout << "In glob1\n";
+  auto names = iter_directory(dirname, dironly);
+  std::vector<fs::path> filtered_names;
+  for (auto &n : names) {
+    if (!is_hidden(n.string())) {
+      filtered_names.push_back(n.filename());
+      // if (n.is_relative()) {
+      //   // std::cout << "Filtered (Relative): " << n << "\n";
+      //   filtered_names.push_back(fs::relative(n));
+      // } else {
+      //   // std::cout << "Filtered (Absolute): " << n << "\n";
+      //   filtered_names.push_back(n.filename());
+      // }
+    }
+  }
+  return filter(filtered_names, pattern);
+}
+
+static inline 
+std::vector<fs::path> glob0(const fs::path &dirname, const fs::path &basename,
+                            bool /*dironly*/) {
+  // std::cout << "In glob0\n";
+  std::vector<fs::path> result;
+  if (basename.empty()) {
+    // 'q*x/' should match only directories.
+    if (fs::is_directory(dirname)) {
+      result = {basename};
+    }
+  } else {
+    if (fs::exists(dirname / basename)) {
+      result = {basename};
+    }
+  }
+  return result;
+}
+
+static inline 
+std::vector<fs::path> glob(const std::string &pathname, bool recursive = false,
+                           bool dironly = false) {
+  std::vector<fs::path> result;
+
+  auto path = fs::path(pathname);
+
+  if (pathname[0] == '~') {
+    // expand tilde
+    path = expand_tilde(path);
+  }
+
+  auto dirname = path.parent_path();
+  const auto basename = path.filename();
+
+  if (!has_magic(pathname)) {
+    assert(!dironly);
+    if (!basename.empty()) {
+      if (fs::exists(path)) {
+        result.push_back(path);
+      }
+    } else {
+      // Patterns ending with a slash should match only directories
+      if (fs::is_directory(dirname)) {
+        result.push_back(path);
+      }
+    }
+    return result;
+  }
+
+  if (dirname.empty()) {
+    if (recursive && is_recursive(basename.string())) {
+      return glob2(dirname, basename.string(), dironly);
+    } else {
+      return glob1(dirname, basename.string(), dironly);
+    }
+  }
+
+  std::vector<fs::path> dirs;
+  if (dirname != fs::path(pathname) && has_magic(dirname.string())) {
+    dirs = glob(dirname.string(), recursive, true);
+  } else {
+    dirs = {dirname};
+  }
+
+  std::function<std::vector<fs::path>(const fs::path &, const std::string &, bool)>
+      glob_in_dir;
+  if (has_magic(basename.string())) {
+    if (recursive && is_recursive(basename.string())) {
+      glob_in_dir = glob2;
+    } else {
+      glob_in_dir = glob1;
+    }
+  } else {
+    glob_in_dir = glob0;
+  }
+
+  for (auto &d : dirs) {
+    for (auto &name : glob_in_dir(d, basename.string(), dironly)) {
+      fs::path subresult = name;
+      if (name.parent_path().empty()) {
+        subresult = d / name;
+      }
+      result.push_back(subresult);
+    }
+  }
+
+  return result;
+}
+
+} // namespace end
+
+static inline 
+std::vector<fs::path> glob(const std::string &pathname) {
+  return glob(pathname, false);
+}
+
+static inline 
+std::vector<fs::path> rglob(const std::string &pathname) {
+  return glob(pathname, true);
+}
+
+static inline 
+std::vector<fs::path> glob(const std::vector<std::string> &pathnames) {
+  std::vector<fs::path> result;
+  for (auto &pathname : pathnames) {
+    for (auto &match : glob(pathname, false)) {
+      result.push_back(std::move(match));
+    }
+  }
+  return result;
+}
+
+static inline 
+std::vector<fs::path> rglob(const std::vector<std::string> &pathnames) {
+  std::vector<fs::path> result;
+  for (auto &pathname : pathnames) {
+    for (auto &match : glob(pathname, true)) {
+      result.push_back(std::move(match));
+    }
+  }
+  return result;
+}
+
+static inline 
+std::vector<fs::path>
+glob(const std::initializer_list<std::string> &pathnames) {
+  return glob(std::vector<std::string>(pathnames));
+}
+
+static inline 
+std::vector<fs::path>
+rglob(const std::initializer_list<std::string> &pathnames) {
+  return rglob(std::vector<std::string>(pathnames));
+}
+
+} // namespace glob

--- a/Champollion/main.cpp
+++ b/Champollion/main.cpp
@@ -147,7 +147,7 @@ bool getProgramOptions(int argc, char* argv[], Params& params)
 }
 
 typedef std::vector<std::string> ProcessResults;
-ProcessResults processFile(fs::path file, Params& params)
+ProcessResults processFile(fs::path file, Params params)
 {
     ProcessResults result;
     Pex::Binary pex;
@@ -250,14 +250,14 @@ int main(int argc, char* argv[])
                         if (_stricmp(entry->path().extension().string().c_str(), ".pex") == 0)
                         {
 
-                            results.push_back(std::async(std::launch::async, processFile, fs::path(entry->path()), args));
+                            results.push_back(std::move(std::async(std::launch::async, processFile, fs::path(entry->path()), args)));
                         }
                         entry++;
                     }
                 }
                 else
                 {
-                    results.push_back(std::async(std::launch::async, processFile, path, args));
+                    results.push_back(std::move(std::async(std::launch::async, processFile, path, args)));
                 }
             }
 

--- a/Champollion/main.cpp
+++ b/Champollion/main.cpp
@@ -3,10 +3,10 @@
 #include <boost/program_options.hpp>
 namespace options = boost::program_options;
 
-#include <boost/filesystem.hpp>
-namespace fs = boost::filesystem;
+#include <filesystem>
+namespace fs = std::filesystem;
 
-#include <boost/format.hpp>
+#include <format>
 
 #include <chrono>
 #include <future>
@@ -162,7 +162,7 @@ ProcessResults processFile(fs::path file, Params params)
     }
     catch(std::exception& ex)
     {
-       result.push_back(boost::str(boost::format("ERROR: %1% : %2%") % file.string() % ex.what()));
+       result.push_back(std::format("ERROR: {} : {}", file.string(), ex.what()));
        return result;
     }
     if (params.outputAssembly)
@@ -174,11 +174,11 @@ ProcessResults processFile(fs::path file, Params params)
             Decompiler::AsmCoder asmCoder(new Decompiler::StreamWriter(asmStream));
 
             asmCoder.code(pex);
-            result.push_back(boost::str(boost::format("%1% dissassembled to %2%") % file.string() % asmFile.string()));
+            result.push_back(std::format("{} dissassembled to {}", file.string(), asmFile.string()));
         }
         catch(std::exception& ex)
         {
-            result.push_back(boost::str(boost::format("ERROR: %1% : %2%") % file.string() % ex.what()));
+            result.push_back(std::format("ERROR: {} : {}",file.string(),ex.what()));
             fs::remove(asmFile);
         }
     }
@@ -190,11 +190,11 @@ ProcessResults processFile(fs::path file, Params params)
         Decompiler::PscCoder pscCoder(new Decompiler::StreamWriter(pscStream));
 
         pscCoder.outputAsmComment(params.outputComment).outputWriteHeader(params.writeHeader).code(pex);
-        result.push_back(boost::str(boost::format("%1% decompiled to %2%") % file.string() % pscFile.string()));
+        result.push_back(std::format("{} decompiled to {}", file.string(), pscFile.string()));
     }
     catch(std::exception& ex)
     {
-        result.push_back(boost::str(boost::format("ERROR: %1% : %2%") % file.string() % ex.what()));
+        result.push_back(std::format("ERROR: {} : {}", file.string() , ex.what()));
         fs::remove(pscFile);
     }
     return result;

--- a/Champollion/main.cpp
+++ b/Champollion/main.cpp
@@ -24,6 +24,7 @@ struct Params
 {
     bool outputAssembly;
     bool outputComment;
+    bool writeHeader;
     bool parallel;
 
     fs::path assemblyDir;
@@ -36,17 +37,19 @@ bool getProgramOptions(int argc, char* argv[], Params& params)
 {
     params.outputAssembly = false;
     params.outputComment = false;
+    params.writeHeader = false;
     params.parallel = false;
     params.assemblyDir = fs::path(".");
     params.papyrusDir = fs::path(".");
 
 
-    options::options_description desc("Champollion PEX decompiler V1.0.6");
+    options::options_description desc("Champollion PEX decompiler V1.0.8");
     desc.add_options()
             ("help,h", "Display the help message")
             ("asm,a", options::value<std::string>()->implicit_value(""), "Output assembly file")
             ("psc,p", options::value<std::string>(), "Name of the output dir for psc decompilation")
             ("comment,c", "Output assembly in comments of the decompiled psc file")
+            ("header,e", "Write header to decompiled psc file")
             ("threaded,t", "Run decompilation in parallel mode")
     ;
     options::options_description files;
@@ -79,6 +82,7 @@ bool getProgramOptions(int argc, char* argv[], Params& params)
     }
 
     params.outputComment = (args.count("comment") != 0);
+    params.writeHeader = (args.count("header") != 0);
     params.parallel = (args.count("threaded") != 0);
 
     try
@@ -185,7 +189,7 @@ ProcessResults processFile(fs::path file, Params params)
         std::ofstream pscStream(pscFile.string());
         Decompiler::PscCoder pscCoder(new Decompiler::StreamWriter(pscStream));
 
-        pscCoder.outputAsmComment(params.outputComment).code(pex);
+        pscCoder.outputAsmComment(params.outputComment).outputWriteHeader(params.writeHeader).code(pex);
         result.push_back(boost::str(boost::format("%1% decompiled to %2%") % file.string() % pscFile.string()));
     }
     catch(std::exception& ex)

--- a/Champollion/main.cpp
+++ b/Champollion/main.cpp
@@ -48,7 +48,7 @@ bool getProgramOptions(int argc, char* argv[], Params& params)
     params.assemblyDir = fs::current_path();
     params.papyrusDir = fs::current_path();
 
-    options::options_description desc("Champollion PEX decompiler V1.0.8");
+    options::options_description desc("Champollion PEX decompiler V1.1.0");
     desc.add_options()
             ("help,h", "Display the help message")
             ("asm,a", options::value<std::string>()->implicit_value(""), "Output assembly file(s) to this directory")

--- a/Decompiler/AsmCoder.hpp
+++ b/Decompiler/AsmCoder.hpp
@@ -30,7 +30,7 @@ protected:
     void writeFunction(int i, const Pex::Function& function, const Pex::Binary& pex, const Pex::DebugInfo::FunctionInfo* info, const std::string& name="");
     void writeCode(int i, const Pex::Instructions& instructions, const Pex::DebugInfo::FunctionInfo *info);
 
-    void writeUserFlags(std::ostream& stream, const Pex::UserFlagged& flagged, const Pex::Binary& pex);
+    void writeUserFlags(std::ostream&& stream, const Pex::UserFlagged& flagged, const Pex::Binary& pex);
 
 };
 }

--- a/Decompiler/Coder.cpp
+++ b/Decompiler/Coder.cpp
@@ -29,6 +29,8 @@ void Decompiler::Coder::write(const std::string &line)
 {
     m_Writer->writeLine(line);
 }
+template<class T> static constexpr bool IsAnOstream = std::is_base_of<std::decay_t<T>, std::ostream>::value;
+template<class T> static constexpr bool IsAnOStringstream = std::is_base_of<std::decay_t<T>, std::ostringstream>::value;
 
 /**
  * @brief Write the content of a ostringstream.
@@ -37,7 +39,7 @@ void Decompiler::Coder::write(const std::string &line)
  *  write(indent(i) << "line data");
  * @param stream The stream as an ostream.
  */
-void Decompiler::Coder::write(std::ostream &stream)
+void Decompiler::Coder::write(std::ostream&& stream)
 {
     auto& sstream = static_cast<std::ostringstream&>(stream);
     m_Writer->writeLine(sstream.str());

--- a/Decompiler/Coder.hpp
+++ b/Decompiler/Coder.hpp
@@ -23,7 +23,7 @@ public:
 
 protected:
     void write(const std::string& line);
-    void write(std::ostream& stream);
+    void write(std::ostream&& stream);
 
 
     std::ostringstream indent(int i);

--- a/Decompiler/DumpTree.hpp
+++ b/Decompiler/DumpTree.hpp
@@ -16,7 +16,7 @@ namespace Decompiler
 class DumpTree : public Node::VisitorBase
 {
 private:
-    std::function<void (std::ostream& stream)> m_Callback;
+    std::function<void (std::ostream&& stream)> m_Callback;
     std::uint32_t m_Indent;
 public:
     DumpTree(decltype(m_Callback) callback) :
@@ -34,7 +34,7 @@ public:
     {
         std::ostringstream result;
         result << ";";
-        for (auto i = 0; i < m_Indent; ++i)
+        for (uint32_t i = 0; i < m_Indent; ++i)
         {
             result << " ";
         }
@@ -43,7 +43,7 @@ public:
 
     void enter(const char* text, Node::Base* node)
     {
-        m_Callback(indent() << text << "<" << node << "> (" << node->getBegin() << "," << node->getEnd() << ")");
+        m_Callback((indent() << text << "<" << node << "> (" << node->getBegin() << "," << node->getEnd() << ")"));
         ++m_Indent;
     }
     void leave()
@@ -62,7 +62,7 @@ public:
     virtual void visit(Node::BinaryOperator* node)
     {
         enter("Binary", node);
-        m_Callback(indent() << "In:" << node->getResult()) ;
+        m_Callback(indent() << "In:" << node->getResult().asString()) ;
         m_Callback(indent() << "Left:");
         node->getLeft()->visit(this);
         m_Callback(indent() << "Op:" << node->getOperator() << " P:" << (int)node->getPrecedence());
@@ -102,7 +102,7 @@ public:
     virtual void visit(Node::Copy* node)
     {
         enter("Copy", node);
-        m_Callback(indent() << "In:" << node->getResult());
+        m_Callback(indent() << "In:" << node->getResult().asString());
         m_Callback(indent() << "Value:");
         node->getValue()->visit(this);
         leave();
@@ -110,8 +110,8 @@ public:
     virtual void visit(Node::Cast* node)
     {
         enter("Cast", node);
-        m_Callback(indent() << "In:" << node->getResult());
-        m_Callback(indent() << "As:" << node->getType());
+        m_Callback(indent() << "In:" << node->getResult().asString());
+        m_Callback(indent() << "As:" << node->getType().asString());
         m_Callback(indent() << "Value:");
         node->getValue()->visit(this);
         leave();
@@ -120,8 +120,8 @@ public:
     virtual void visit(Node::CallMethod* node)
     {
         enter("Call", node);
-        m_Callback(indent() << "In:" << node->getResult());
-        m_Callback(indent() << "Method:" << node->getMethod());
+        m_Callback(indent() << "In:" << node->getResult().asString());
+        m_Callback(indent() << "Method:" << node->getMethod().asString());
         m_Callback(indent() << "On:");
         node->getObject()->visit(this);
         for (auto param : *node->getParameters())
@@ -150,8 +150,8 @@ public:
     virtual void visit(Node::PropertyAccess* node)
     {
         enter("PropertyAccess", node);
-        m_Callback(indent() << "In:" << node->getResult());
-        m_Callback(indent() << "Property:" << node->getProperty());
+        m_Callback(indent() << "In:" << node->getResult().asString());
+        m_Callback(indent() << "Property:" << node->getProperty().asString());
         m_Callback(indent() << "On:");
         node->getObject()->visit(this);
         leave();
@@ -160,7 +160,7 @@ public:
     virtual void visit(Node::ArrayCreate* node)
     {
         enter("ArrayCreate", node);
-        m_Callback(indent() << "Type:" << node->getType());
+        m_Callback(indent() << "Type:" << node->getType().asString());
         //m_Callback(indent() << "Size:" << node->getSize());
         leave();
     }
@@ -176,7 +176,7 @@ public:
     virtual void visit(Node::ArrayAccess* node)
     {
         enter("ArrayAccess", node);
-        m_Callback(indent() << "In:" << node->getResult());
+        m_Callback(indent() << "In:" << node->getResult().asString());
         m_Callback(indent() << "Array:");
         node->getArray()->visit(this);
         m_Callback(indent() << "Index:");
@@ -198,12 +198,12 @@ public:
             break;
         case Pex::ValueType::Identifier:
         {
-            m_Callback(indent() << "Identifier:" << value.getId());
+            m_Callback(indent() << "Identifier:" << value.getId().asString());
         }
             break;
         case Pex::ValueType::String:
         {
-            m_Callback(indent() << "String:" << value.getString());
+            m_Callback(indent() << "String:" << value.getString().asString());
         }
             break;
         case Pex::ValueType::Integer:
@@ -259,7 +259,7 @@ public:
     virtual void visit(Node::Declare* node)
     {
         enter("Declare", node);
-        m_Callback(indent() << "Type:" << node->getType());
+        m_Callback(indent() << "Type:" << node->getType().asString());
         m_Callback(indent() << "Name:");
         node->getObject()->visit(this);
         leave();

--- a/Decompiler/DumpTree.hpp
+++ b/Decompiler/DumpTree.hpp
@@ -16,7 +16,7 @@ namespace Decompiler
 class DumpTree : public Node::VisitorBase
 {
 private:
-    std::function<void (std::ostream&& stream)> m_Callback;
+    std::function<void (std::ostringstream stream)> m_Callback;
     std::uint32_t m_Indent;
 public:
     DumpTree(decltype(m_Callback) callback) :
@@ -62,7 +62,7 @@ public:
     virtual void visit(Node::BinaryOperator* node)
     {
         enter("Binary", node);
-        m_Callback(indent() << "In:" << node->getResult().asString()) ;
+        m_Callback(indent() << "In:" << node->getResult()) ;
         m_Callback(indent() << "Left:");
         node->getLeft()->visit(this);
         m_Callback(indent() << "Op:" << node->getOperator() << " P:" << (int)node->getPrecedence());
@@ -102,7 +102,7 @@ public:
     virtual void visit(Node::Copy* node)
     {
         enter("Copy", node);
-        m_Callback(indent() << "In:" << node->getResult().asString());
+        m_Callback(indent() << "In:" << node->getResult());
         m_Callback(indent() << "Value:");
         node->getValue()->visit(this);
         leave();
@@ -110,8 +110,8 @@ public:
     virtual void visit(Node::Cast* node)
     {
         enter("Cast", node);
-        m_Callback(indent() << "In:" << node->getResult().asString());
-        m_Callback(indent() << "As:" << node->getType().asString());
+        m_Callback(indent() << "In:" << node->getResult());
+        m_Callback(indent() << "As:" << node->getType());
         m_Callback(indent() << "Value:");
         node->getValue()->visit(this);
         leave();
@@ -120,8 +120,8 @@ public:
     virtual void visit(Node::CallMethod* node)
     {
         enter("Call", node);
-        m_Callback(indent() << "In:" << node->getResult().asString());
-        m_Callback(indent() << "Method:" << node->getMethod().asString());
+        m_Callback(indent() << "In:" << node->getResult());
+        m_Callback(indent() << "Method:" << node->getMethod());
         m_Callback(indent() << "On:");
         node->getObject()->visit(this);
         for (auto param : *node->getParameters())
@@ -143,15 +143,19 @@ public:
     {
         enter("Return", node);
         m_Callback(indent() << "Value:");
-        node->getValue()->visit(this);
+        if (node->getValue()) {
+            node->getValue()->visit(this);
+        } else {
+            m_Callback(indent() << "<NONE>");
+        }
         leave();
     }
 
     virtual void visit(Node::PropertyAccess* node)
     {
         enter("PropertyAccess", node);
-        m_Callback(indent() << "In:" << node->getResult().asString());
-        m_Callback(indent() << "Property:" << node->getProperty().asString());
+        m_Callback(indent() << "In:" << node->getResult());
+        m_Callback(indent() << "Property:" << node->getProperty());
         m_Callback(indent() << "On:");
         node->getObject()->visit(this);
         leave();
@@ -160,8 +164,8 @@ public:
     virtual void visit(Node::ArrayCreate* node)
     {
         enter("ArrayCreate", node);
-        m_Callback(indent() << "Type:" << node->getType().asString());
-        //m_Callback(indent() << "Size:" << node->getSize());
+        m_Callback(indent() << "Type:" << node->getType());
+        //m_Callback(indent() << "Size:" << node->getSize()); // TODO: Add size back to ArrayCreate?
         leave();
     }
 
@@ -176,7 +180,7 @@ public:
     virtual void visit(Node::ArrayAccess* node)
     {
         enter("ArrayAccess", node);
-        m_Callback(indent() << "In:" << node->getResult().asString());
+        m_Callback(indent() << "In:" << node->getResult());
         m_Callback(indent() << "Array:");
         node->getArray()->visit(this);
         m_Callback(indent() << "Index:");
@@ -198,12 +202,12 @@ public:
             break;
         case Pex::ValueType::Identifier:
         {
-            m_Callback(indent() << "Identifier:" << value.getId().asString());
+            m_Callback(indent() << "Identifier:" << value.getId());
         }
             break;
         case Pex::ValueType::String:
         {
-            m_Callback(indent() << "String:" << value.getString().asString());
+            m_Callback(indent() << "String:" << value.getString());
         }
             break;
         case Pex::ValueType::Integer:
@@ -259,7 +263,7 @@ public:
     virtual void visit(Node::Declare* node)
     {
         enter("Declare", node);
-        m_Callback(indent() << "Type:" << node->getType().asString());
+        m_Callback(indent() << "Type:" << node->getType());
         m_Callback(indent() << "Name:");
         node->getObject()->visit(this);
         leave();

--- a/Decompiler/PscCoder.cpp
+++ b/Decompiler/PscCoder.cpp
@@ -56,6 +56,32 @@ Decompiler::PscCoder &Decompiler::PscCoder::outputAsmComment(bool commentAsm)
 }
 
 /**
+ * @brief Write the content of the PEX header as a block comment.
+ * @param pex Binary to decompile.
+ */
+void Decompiler::PscCoder::writeHeader(const Pex::Binary &pex)
+{
+    auto& header = pex.getHeader();
+    auto& debug  = pex.getDebugInfo();
+    write(";/ Decompiled by Champollion V1.0.6");
+    write(indent(0) << "PEX format v" << (int)header.getMajorVersion() << "." << (int)header.getMinorVersion() << " GameID: " << header.getGameID());
+    write(indent(0) << "Source   : " << header.getSourceFileName());
+    if (debug.getModificationTime() != 0)
+    {
+        write(indent(0) << "Modified : " << std::put_time(std::localtime(&debug.getModificationTime()), "%Y-%m-%d %H:%M:%S"));
+        //for (auto& f : debug.getFunctionInfos()) {
+        //  write(indent(0) << f.getObjectName().asString() << ":" << f.getStateName().asString() << ":" << f.getFunctionName().asString() << " type: " << (int)f.getFunctionType());
+        //  for (auto& l : f.getLineNumbers())
+        //    write(indent(1) << "Line: " << l);
+        //}
+    }
+    write(indent(0) << "Compiled : " << std::put_time(std::localtime(&header.getCompilationTime()), "%Y-%m-%d %H:%M:%S"));
+    write(indent(0) << "User     : " << header.getUserName());
+    write(indent(0) << "Computer : " << header.getComputerName());
+    write("/;");
+}
+
+/**
  * @brief Write an object contained in the binary.
  * @param object Object to decompile
  * @param pex Binary to decompile.

--- a/Decompiler/PscCoder.cpp
+++ b/Decompiler/PscCoder.cpp
@@ -72,7 +72,7 @@ void Decompiler::PscCoder::writeObject(const Pex::Object &object, const Pex::Bin
       stream << " Const";
 
     writeUserFlag(stream, object, pex);
-    write(stream);
+    write(stream.str());
 
     writeDocString(0, object);
 
@@ -104,7 +104,7 @@ void Decompiler::PscCoder::writeObject(const Pex::Object &object, const Pex::Bin
 */
 void Decompiler::PscCoder::writeStructs(const Pex::Object& object, const Pex::Binary& pex) {
     for (auto& sInfo : object.getStructInfos()) {
-        write(indent(0) << "Struct " << sInfo.getName());
+        write(indent(0) << "Struct " << sInfo.getName().asString());
 
         bool foundInfo = false;
         if (pex.getDebugInfo().getStructOrders().size()) {
@@ -155,7 +155,7 @@ void Decompiler::PscCoder::writeStructs(const Pex::Object& object, const Pex::Bi
 void Decompiler::PscCoder::writeStructMember(const Pex::StructInfo::Member& member, const Pex::Binary& pex)
 {
     auto stream = indent(1);
-    stream << mapType(member.getTypeName().asString()) << " " << member.getName();
+    stream << mapType(member.getTypeName().asString()) << " " << member.getName().asString();
 
     if (member.getValue().getType() != Pex::ValueType::None) {
         stream << " = " << member.getValue().toString();
@@ -163,7 +163,7 @@ void Decompiler::PscCoder::writeStructMember(const Pex::StructInfo::Member& memb
     writeUserFlag(stream, member, pex);
     if (member.getConstFlag())
       stream << " Const";
-    write(stream);
+    write(stream.str());
     writeDocString(1, member);
 }
 
@@ -195,7 +195,7 @@ void Decompiler::PscCoder::writeProperties(const Pex::Object &object, const Pex:
                         auto stream = indent(0);
                         stream << "Group " << propGroup.getGroupName();
                         writeUserFlag(stream, propGroup, pex);
-                        write(stream);
+                        write(stream.str());
                         writeDocString(0, propGroup);
                         propertyIndent = 1;
                     }
@@ -245,7 +245,7 @@ void Decompiler::PscCoder::writeProperty(int i, const Pex::Property& prop, const
                            prop.getReadFunction().getInstructions().size() == 1 &&
                            prop.getReadFunction().getInstructions()[0].getOpCode() == Pex::OpCode::RETURN &&
                            prop.getReadFunction().getInstructions()[0].getArgs().size() == 1;
-    stream << mapType(prop.getTypeName().asString()) << " Property " << prop.getName();
+    stream << mapType(prop.getTypeName().asString()) << " Property " << prop.getName().asString();
     if (prop.hasAutoVar()) {
         auto var = object.getVariables().findByName(prop.getAutoVarName());
         if (var == nullptr)
@@ -265,7 +265,7 @@ void Decompiler::PscCoder::writeProperty(int i, const Pex::Property& prop, const
       stream << " AutoReadOnly";
     }
     writeUserFlag(stream, prop, pex);
-    write(stream);
+    write(stream.str());
     writeDocString(i, prop);
 
     if (!prop.hasAutoVar() && !isAutoReadOnly) {
@@ -305,7 +305,7 @@ void Decompiler::PscCoder::writeVariables(const Pex::Object &object, const Pex::
 
         if (m_CommentAsm || !compilerGenerated)
         {
-            write(stream);
+            write(stream.str());
         }
     }
 }
@@ -340,7 +340,7 @@ void Decompiler::PscCoder::writeStates(const Pex::Object &object, const Pex::Bin
             {
                 stream << "Auto ";
             }
-            write(stream << "State " << state.getName().asString());
+            write(stream.str() + "State " + state.getName().asString());
             writeFunctions(1, state, object, pex);
             write(indent(0) << "EndState");
         }
@@ -423,7 +423,7 @@ void Decompiler::PscCoder::writeFunction(int i, const Pex::Function &function, c
             stream << " Native";
         }
         writeUserFlag(stream, function, pex);
-        write(stream);
+        write(stream.str());
 
         writeDocString(i, function);
 
@@ -458,7 +458,7 @@ void Decompiler::PscCoder::writeUserFlag(std::ostream& stream, const Pex::UserFl
     {
         if (flags & flag.getFlagMask())
         {
-            stream << " " << flag.getName();
+            stream << " " << flag.getName().asString();
         }
     }
 }

--- a/Decompiler/PscCoder.cpp
+++ b/Decompiler/PscCoder.cpp
@@ -1,7 +1,5 @@
 #include "PscCoder.hpp"
 
-#include <boost/algorithm/string/case_conv.hpp>
-
 #include <cassert>
 #include <ctime>
 #include <iostream>
@@ -609,6 +607,11 @@ static const std::map<std::string, std::string> prettyTypeNameMap {
     { "worldspace", "WorldSpace" },
 };
 
+void str_to_lower(std::string &p_str){
+    for (int i = 0; i < p_str.size(); i++){
+        p_str[i] = tolower(p_str[i]);
+    }
+}
 /**
 * @brief Map the type name used by the compiler to the form most used by people.
 * @param type The type to map.
@@ -618,7 +621,7 @@ std::string Decompiler::PscCoder::mapType(std::string type)
     if (type.length() > 2 && type[type.length() - 2] == '[' && type[type.length() - 1] == ']')
         return mapType(type.substr(0, type.length() - 2)) + "[]";
     auto lowerType = type;
-    boost::algorithm::to_lower(lowerType);
+    str_to_lower(lowerType);
     auto a = prettyTypeNameMap.find(lowerType);
     if (a != prettyTypeNameMap.end())
         return a->second;

--- a/Decompiler/PscCoder.cpp
+++ b/Decompiler/PscCoder.cpp
@@ -20,7 +20,8 @@
  */
 Decompiler::PscCoder::PscCoder(Decompiler::OutputWriter *writer)  :
     Coder(writer),
-    m_CommentAsm(false)
+    m_CommentAsm(false),
+    m_WriteHeader(false)
 {
 }
 
@@ -37,6 +38,10 @@ Decompiler::PscCoder::~PscCoder()
  */
 void Decompiler::PscCoder::code(const Pex::Binary &pex)
 {
+    if (m_WriteHeader) 
+    {
+        writeHeader(pex);
+    }
     for(auto& object : pex.getObjects())
     {
         writeObject(object, pex);
@@ -56,6 +61,17 @@ Decompiler::PscCoder &Decompiler::PscCoder::outputAsmComment(bool commentAsm)
 }
 
 /**
+ * @brief Set the option to add a header to the decompiled script.
+ * @param writeHeader True to write the header.
+ * @return A reference to this.
+ */
+Decompiler::PscCoder &Decompiler::PscCoder::outputWriteHeader(bool writeHeader)
+{
+    m_WriteHeader = writeHeader;
+    return *this;
+}
+
+/**
  * @brief Write the content of the PEX header as a block comment.
  * @param pex Binary to decompile.
  */
@@ -63,7 +79,7 @@ void Decompiler::PscCoder::writeHeader(const Pex::Binary &pex)
 {
     auto& header = pex.getHeader();
     auto& debug  = pex.getDebugInfo();
-    write(";/ Decompiled by Champollion V1.0.6");
+    write(";/ Decompiled by Champollion V1.0.8"); // TODO: Make this get the version number dynamically
     write(indent(0) << "PEX format v" << (int)header.getMajorVersion() << "." << (int)header.getMinorVersion() << " GameID: " << header.getGameID());
     write(indent(0) << "Source   : " << header.getSourceFileName());
     if (debug.getModificationTime() != 0)

--- a/Decompiler/PscCoder.cpp
+++ b/Decompiler/PscCoder.cpp
@@ -130,7 +130,7 @@ void Decompiler::PscCoder::writeHeader(const Pex::Binary &pex)
 {
     auto& header = pex.getHeader();
     auto& debug  = pex.getDebugInfo();
-    write(";/ Decompiled by Champollion V1.0.8"); // TODO: Make this get the version number dynamically
+    write(";/ Decompiled by Champollion V1.1.0"); // TODO: Make this get the version number dynamically
     write(indent(0) << "PEX format v" << (int)header.getMajorVersion() << "." << (int)header.getMinorVersion() << " GameID: " << header.getGameID());
     write(indent(0) << "Source   : " << header.getSourceFileName());
     if (debug.getModificationTime() != 0)

--- a/Decompiler/PscCoder.hpp
+++ b/Decompiler/PscCoder.hpp
@@ -17,7 +17,7 @@ public:
     virtual void code(const Pex::Binary& pex);
 
     PscCoder& outputAsmComment(bool commentAsm);
-
+    PscCoder& outputWriteHeader(bool writeHeader);
     static std::string mapType(std::string type);
 protected:
 
@@ -37,5 +37,6 @@ protected:
 
 protected:
     bool m_CommentAsm;
+    bool m_WriteHeader;
 };
 }

--- a/Decompiler/PscCoder.hpp
+++ b/Decompiler/PscCoder.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include "Coder.hpp"
 
 
@@ -11,11 +10,14 @@ class PscCoder :
         public Coder
 {
 public:
+    PscCoder(OutputWriter* writer, bool commentAsm, bool writeHeader, bool traceDecompilation, bool dumpTree, std::string traceDir);
     PscCoder(OutputWriter* writer);
     ~PscCoder();
 
     virtual void code(const Pex::Binary& pex);
 
+    PscCoder& outputDecompilationTrace(bool traceDecompilation);
+    PscCoder& outputDumpTree(bool dumpTree);
     PscCoder& outputAsmComment(bool commentAsm);
     PscCoder& outputWriteHeader(bool writeHeader);
     static std::string mapType(std::string type);
@@ -38,5 +40,8 @@ protected:
 protected:
     bool m_CommentAsm;
     bool m_WriteHeader;
+    bool m_TraceDecompilation;
+    bool m_DumpTree;
+    std::string m_OutputDir;
 };
 }

--- a/Decompiler/PscDecompiler.cpp
+++ b/Decompiler/PscDecompiler.cpp
@@ -5,7 +5,8 @@
 #include <iostream>
 #include <iomanip>
 #include <iterator>
-
+#include <atomic>
+#include <mutex>
 
 #include "Node/Nodes.hpp"
 #include "Node/WithNode.hpp"
@@ -43,6 +44,8 @@ std::string getVarName(const Pex::StringTable::Index& var)
     return name;
 }
 
+static std::atomic_size_t unnamed_num{0};
+
 /**
  * @brief Constructor.
  * The constructor associate the function and object to the decompiler.
@@ -50,16 +53,48 @@ std::string getVarName(const Pex::StringTable::Index& var)
  * @param function Function to decompile.
  * @param object Object containing the function.
  * @param commentAsm True to output assembly instruction comments.
+ * @param traceDecompilation True to output decompilation tracing to the rebuild log.
+ * @param dumpTree True to output the entire tree for each block (true by default if traceDecompilation is true).
  */
-Decompiler::PscDecompiler::PscDecompiler(const Pex::Function &function, const Pex::Object &object, bool commentAsm = false) :
+Decompiler::PscDecompiler::PscDecompiler(   const Pex::Function &function,
+                                            const Pex::Object &object,
+                                            bool commentAsm = false,
+                                            bool traceDecompilation = false,
+                                            bool dumpTree = true,
+                                            std::string outputDir = "" ) :
     m_Function(function),
     m_Object(object),
-    m_CommentAsm(commentAsm)
+    m_CommentAsm(commentAsm),
+    m_TraceDecompilation(traceDecompilation),
+    m_DumpTree(dumpTree), // Note that while dumpTree is true by default, it will not do anything unless traceDecompilation is true
+    m_OutputDir(outputDir)
 {
-#if defined(TRACE_DECOMPILATION) && defined(REBUILD_LOG)
-    m_Log.open(std::string("rebuild-") + object.getName().asString()
-               + "-" + (function.getName().isValid()?function.getName().asString():std::string("unnamed")) + ".txt");
-#endif
+    if (m_TraceDecompilation)
+    {
+        auto fileprefix = std::string("rebuild-") + object.getName()
+                + "-";     
+        std::string filename;
+        if (function.getName().isValid()){
+            filename = fileprefix + function.getName() + ".txt";
+        } else {
+            fileprefix += "unnamed";
+            // in case of parallel execution
+            static std::mutex unnamed_num_mutex;
+            std::lock_guard m(unnamed_num_mutex);
+            filename = fileprefix + std::to_string(++unnamed_num) + ".txt";
+        }
+        std::replace(filename.begin(), filename.end(), '#', '_');
+        std::replace(filename.begin(), filename.end(), ':', '_');
+        std::string filepath = !m_OutputDir.empty() ? m_OutputDir + "/" + filename : filename;
+        m_Log.open(filepath);
+        if (m_Log.fail())
+        {
+            m_TraceDecompilation = false;
+            static std::mutex cerr_mutex;
+            std::lock_guard m(cerr_mutex);
+            std::cerr << "Failed to open " << filepath << ", tracing disabled." << std::endl;
+        }
+    }
     if (m_Function.getInstructions().size() == 0)
     {
         push_back("; Empty function");
@@ -765,10 +800,11 @@ void Decompiler::PscDecompiler::rebuildExpression(Node::BasePtr scope)
  */
 void Decompiler::PscDecompiler::rebuildBooleanOperators(size_t startBlock, size_t endBlock)
 {
-#ifdef TRACE_DECOMPILATION
-    m_Log << "--- BEGIN REBUILD : " << startBlock << " " << endBlock << std::endl;
-    dumpBlock(startBlock, endBlock);
-#endif
+    if (m_TraceDecompilation)
+    {
+        m_Log << "--- BEGIN REBUILD : " << startBlock << " " << endBlock << std::endl;
+        dumpBlock(startBlock, endBlock);
+    }
     auto begin = m_CodeBlocs.find(startBlock);
     auto end = m_CodeBlocs.find(endBlock);
     auto it = begin;
@@ -776,31 +812,34 @@ void Decompiler::PscDecompiler::rebuildBooleanOperators(size_t startBlock, size_
     {
         auto& source = it->second;
         int advance = 1;
-#ifdef TRACE_DECOMPILATION
-        m_Log << "?" << source->getBegin() << " source->isConditional()=" << source->isConditional() <<" "
-            << "source->getScope()->size()=" << source->getScope()->size() <<" "
-            << '\n';
-#endif
+        if (m_TraceDecompilation)
+        {
+            m_Log << "?" << source->getBegin() << " source->isConditional()=" << source->isConditional() <<" "
+                << "source->getScope()->size()=" << source->getScope()->size() <<" "
+                << '\n';
+        }
         // Process only conditional block with at least one statement.
         if (source->isConditional() && source->getScope()->size() != 0)
         {
-#ifdef TRACE_DECOMPILATION
-            m_Log << "??"             << "source->getCondition()=" << source->getCondition() << " "
-                << "source->getScope()->back()->getResult()=" << source->getScope()->back()->getResult() << " "
-                << '\n';
-#endif
+            if (m_TraceDecompilation)
+            {
+                m_Log << "??"             << "source->getCondition()=" << source->getCondition() << " "
+                    << "source->getScope()->back()->getResult()=" << source->getScope()->back()->getResult() << " "
+                    << '\n';
+            }
             // Ensure that the last statement computes the value of the condition variable.
             if (source->getCondition() == source->getScope()->back()->getResult())
             {
-#ifdef TRACE_DECOMPILATION
-            // AND ?
-                m_Log << "AND? "
-                      << "source->onTrue() == source->getEnd() + 1:" << (source->onTrue() == source->getEnd() + 1) << " "
-                      << '\n';
-                m_Log << "OR? "
-                      << "source->onFalse() == source->getEnd() + 1:" << (source->onFalse() == source->getEnd() + 1) << " "
-                      << '\n';
-#endif
+                if (m_TraceDecompilation)
+                {
+                    // AND ?
+                    m_Log << "AND? "
+                        << "source->onTrue() == source->getEnd() + 1:" << (source->onTrue() == source->getEnd() + 1) << " "
+                        << '\n';
+                    m_Log << "OR? "
+                        << "source->onFalse() == source->getEnd() + 1:" << (source->onFalse() == source->getEnd() + 1) << " "
+                        << '\n';
+                }
                 // If the true block is the block directly following this one, it is a potential and
                 bool maybeAnd = (source->onTrue() == source->getEnd() + 1);
                 // If the false block is the block directly following this one, it is a potential or
@@ -815,12 +854,13 @@ void Decompiler::PscDecompiler::rebuildBooleanOperators(size_t startBlock, size_
                     auto & onFalse = m_CodeBlocs[source->onFalse()];
                     if (onTrue->getScope()->size() == 1)
                     {
-#ifdef TRACE_DECOMPILATION
-                        m_Log << "AND@" << source->getBegin() << " "
-                              << "onTrue->getScope()->size() == 1:" << (onTrue->getScope()->size() == 1) << " "
-                              << "onTrue->getScope()->back()->getResult() == source->getCondition():" << (onTrue->getScope()->back()->getResult() == source->getCondition()) << " "
-                              << "\n";
-#endif
+                        if (m_TraceDecompilation)
+                        {
+                            m_Log << "AND@" << source->getBegin() << " "
+                                << "onTrue->getScope()->size() == 1:" << (onTrue->getScope()->size() == 1) << " "
+                                << "onTrue->getScope()->back()->getResult() == source->getCondition():" << (onTrue->getScope()->back()->getResult() == source->getCondition()) << " "
+                                << "\n";
+                        }
                         // The true block computes the same value as the current block, and it is the condition variable
                         // This is a "and" operator
                         if(onTrue->getScope()->size() == 1 && onTrue->getScope()->back()->getResult() == source->getCondition())
@@ -846,10 +886,11 @@ void Decompiler::PscDecompiler::rebuildBooleanOperators(size_t startBlock, size_
                             m_CodeBlocs.erase(onFalse->getBegin());
 
                             advance = 0;
-#ifdef TRACE_DECOMPILATION
-                            m_Log << "AND? " << "detected" << std::endl;
-                            dumpBlock(source->getBegin(), source->getEnd()+1);
-#endif
+                            if (m_TraceDecompilation)
+                            {
+                                m_Log << "AND? " << "detected" << std::endl;
+                                dumpBlock(source->getBegin(), source->getEnd()+1);
+                            }
                         }
                     }
                     it = m_CodeBlocs.find(source->getBegin());
@@ -861,12 +902,13 @@ void Decompiler::PscDecompiler::rebuildBooleanOperators(size_t startBlock, size_
                     rebuildBooleanOperators(source->onFalse(), source->onTrue());
                     auto & onTrue  = m_CodeBlocs[source->onTrue()];
                     auto & onFalse = m_CodeBlocs[source->onFalse()];
-#ifdef TRACE_DECOMPILATION
-                    m_Log << "OR@"  << source->getBegin() << " "
-                          << "onFalse->getScope()->size() == 1:" << (onFalse->getScope()->size() == 1) << " "
-                          << "onFalse->getScope()->back()->getResult() == source->getCondition():" << (onFalse->getScope()->back()->getResult() == source->getCondition()) << " "
-                          << "\n";
-#endif
+                        if (m_TraceDecompilation)
+                        {
+                            m_Log << "OR@"  << source->getBegin() << " "
+                                << "onFalse->getScope()->size() == 1:" << (onFalse->getScope()->size() == 1) << " "
+                                << "onFalse->getScope()->back()->getResult() == source->getCondition():" << (onFalse->getScope()->back()->getResult() == source->getCondition()) << " "
+                                << "\n";
+                        }
                     // The false block computes the same value as the current block, and it is the condition variable
                     // This is a "or operator
                     if(onFalse->getScope()->size() == 1 && onFalse->getScope()->back()->getResult() == source->getCondition())
@@ -891,10 +933,11 @@ void Decompiler::PscDecompiler::rebuildBooleanOperators(size_t startBlock, size_
                         source->setCondition(onTrue->getCondition(), onTrue->onTrue(), onTrue->onFalse());
                         m_CodeBlocs.erase(onTrue->getBegin());
                         advance = 0;
-#ifdef TRACE_DECOMPILATION
-                        m_Log << "OR? " << "detected" << std::endl;
-                        dumpBlock(source->getBegin(), source->getEnd()+1);
-#endif
+                        if (m_TraceDecompilation)
+                        {
+                            m_Log << "OR? " << "detected" << std::endl;
+                            dumpBlock(source->getBegin(), source->getEnd()+1);
+                        }
                     }
                     it = m_CodeBlocs.find(source->getBegin());
                     advance = 0;
@@ -903,10 +946,11 @@ void Decompiler::PscDecompiler::rebuildBooleanOperators(size_t startBlock, size_
         }
         std::advance(it, advance);
     }
-#ifdef TRACE_DECOMPILATION
-    m_Log << "--- END REBUILD : " << startBlock << " " << endBlock << std::endl;
-    dumpBlock(startBlock, endBlock);
-#endif
+    if (m_TraceDecompilation)
+    {
+        m_Log << "--- END REBUILD : " << startBlock << " " << endBlock << std::endl;
+        dumpBlock(startBlock, endBlock);
+    }
 }
 
 /**
@@ -1287,9 +1331,7 @@ void Decompiler::PscDecompiler::cleanUpTree(Node::BasePtr program)
 
 }
 
-#ifdef TRACE_DECOMPILATION
 #include "DumpTree.hpp"
-#endif
 
 /**
  * @brief Generate the code from the program tree.
@@ -1298,13 +1340,17 @@ void Decompiler::PscDecompiler::cleanUpTree(Node::BasePtr program)
  */
 void Decompiler::PscDecompiler::generateCode(Node::BasePtr program)
 {
-#if defined(TRACE_DECOMPILATION) && defined(DUMP_TREE)
-    DumpTree tree([&] (std::ostream& stream)
+    if (m_TraceDecompilation && m_DumpTree)
     {
-        push_back(static_cast<std::ostringstream&>(stream).str());
-    });
-    program->visit(&tree);
-#endif
+        
+        //DumpTree tree([&] (std::string&& line)
+        DumpTree tree([&] (std::ostringstream stream)
+        {
+            push_back(stream.str());
+            //push_back(line);
+        });
+        program->visit(&tree);
+    }
 
     if (m_CommentAsm)
     {
@@ -1364,7 +1410,6 @@ Node::BasePtr Decompiler::PscDecompiler::checkAssign(Node::BasePtr expression) c
     return expression;
 }
 
-#ifdef TRACE_DECOMPILATION
 void Decompiler::PscDecompiler::dumpBlock(size_t startBlock, size_t endBlock)
 {
     auto begin = m_CodeBlocs.find(startBlock);
@@ -1391,15 +1436,18 @@ void Decompiler::PscDecompiler::dumpBlock(size_t startBlock, size_t endBlock)
             }
             m_Log << '\n';
         }
-#ifdef DUMP_TREE
-        DumpTree tree([&] (std::ostream& line)
+        if (m_DumpTree)
         {
-            m_Log << static_cast<std::ostringstream&>(line).str() << '\n';
-        });
-        b->getScope()->visit(&tree);
-#endif
+            //DumpTree tree([&] (std::string&& line)
+            
+            DumpTree tree([&] (std::ostringstream line)
+            {
+                m_Log << line.str() << '\n';
+                // m_Log << line << '\n';
+            });
+            b->getScope()->visit(&tree);
+        }
         m_Log << "------- cond:" << b->getCondition() << " true:" << b->onTrue() << " false:" << b->onFalse() << std::endl;
         ++it;
     }
 }
-#endif

--- a/Decompiler/PscDecompiler.hpp
+++ b/Decompiler/PscDecompiler.hpp
@@ -11,8 +11,6 @@
 
 #include "Node/Base.hpp"
 
-#define TRACE_DECOMPILATION
-
 namespace Decompiler {
 
 /**
@@ -25,7 +23,12 @@ class PscDecompiler :
         public std::vector<std::string>
 {
 public:
-    PscDecompiler(const Pex::Function& function, const Pex::Object& object, bool commentAsm);
+    PscDecompiler(  const Pex::Function& function,
+                    const Pex::Object& object, 
+                    bool commentAsm, 
+                    bool traceDecompilation, 
+                    bool dumpTree,
+                    std::string outputDir);
     ~PscDecompiler();
 
     void decodeToAsm(std::uint8_t level, size_t begin, size_t end);
@@ -58,9 +61,7 @@ protected:
     Node::BasePtr fromValue(size_t ip, const Pex::Value& value) const;
     Node::BasePtr checkAssign(Node::BasePtr expression) const;
 
-#ifdef TRACE_DECOMPILATION
     void dumpBlock(size_t startBlock, size_t endBlock);
-#endif
 protected:
     typedef std::map<size_t, PscCodeBlock*> CodeBlocs;
     CodeBlocs m_CodeBlocs;
@@ -78,10 +79,11 @@ protected:
     bool m_ReturnNone;
 
     bool m_CommentAsm;
+    bool m_TraceDecompilation;
+    bool m_DumpTree;
+    std::string m_OutputDir;
 
-#ifdef TRACE_DECOMPILATION
     std::ofstream m_Log;
-#endif
     Pex::StringTable m_TempTable;
 };
 }

--- a/Doc/Readme.html
+++ b/Doc/Readme.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<title>Champollion V1.0.8 Readme</title>
+	<title>Champollion V1.1.0 Readme</title>
 	<link rel="stylesheet" type="text/css" href="readme.css">
 </head>
 

--- a/Doc/Readme.html
+++ b/Doc/Readme.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<title>Champollion V1.0.1 Readme</title>
+	<title>Champollion V1.0.8 Readme</title>
 	<link rel="stylesheet" type="text/css" href="readme.css">
 </head>
 

--- a/Pex/Binary.cpp
+++ b/Pex/Binary.cpp
@@ -8,7 +8,8 @@
  *
  * This constructor provides a Binary file with empty elements.
  */
-Pex::Binary::Binary()
+Pex::Binary::Binary():
+    m_GameType(UNKNOWN)
 {
 }
 
@@ -120,4 +121,12 @@ Pex::Objects &Pex::Binary::getObjects()
     return m_Objects;
 }
 
+Pex::Binary::GameType Pex::Binary::getGameType() const
+{
+    return m_GameType;
+}
 
+void Pex::Binary::setGameType(Pex::Binary::GameType game_type)
+{
+    m_GameType = game_type;
+}

--- a/Pex/Binary.hpp
+++ b/Pex/Binary.hpp
@@ -16,9 +16,15 @@ namespace Pex {
  * The Binary class reflect the content of a PEX file.
  *
  */
+class FileReader;
 class Binary
 {
 public:
+    enum GameType {
+        UNKNOWN = -1,
+        SKYRIM,
+        FALLOUT4
+    };
     Binary();
     virtual ~Binary();
 
@@ -37,11 +43,16 @@ public:
     const Objects& getObjects() const;
     Objects& getObjects();
 
+    GameType getGameType() const;
+    
 protected:
+    friend FileReader;
+    void setGameType(GameType game_type);
     Header m_Header;
     StringTable m_StringTable;
     DebugInfo m_DebugInfo;
     UserFlags m_UserFlags;
     Objects m_Objects;
+    GameType m_GameType;
 };
 }

--- a/Pex/ByteSwap.hpp
+++ b/Pex/ByteSwap.hpp
@@ -1,4 +1,5 @@
 #include <type_traits>
+#include <cassert>
 // These are backported from STL C++23
 
 constexpr uint16_t _Byteswap_ushort(const uint16_t _Val) noexcept {
@@ -43,4 +44,17 @@ constexpr Integer byteswap(const Integer _Val) noexcept {
     } else {
         static_assert(_always_false_assert<Integer>, "Unexpected integer size");
     }
+}
+
+float byteswap_float(const float _Val) noexcept {
+    float retVal;
+    const auto pVal = reinterpret_cast<const char*>(& _Val);
+    const auto pRetVal = reinterpret_cast<char*>(& retVal);
+    const std::size_t size = sizeof(float);
+    assert(size == 4);
+    for (std::size_t i = 0; i < size; i++)
+    {
+        pRetVal[size - 1 - i] = pVal[i];
+    }
+    return retVal;
 }

--- a/Pex/ByteSwap.hpp
+++ b/Pex/ByteSwap.hpp
@@ -1,0 +1,46 @@
+#include <type_traits>
+// These are backported from STL C++23
+
+constexpr uint16_t _Byteswap_ushort(const uint16_t _Val) noexcept {
+    if (std::_Is_constant_evaluated()) {
+        return static_cast<unsigned short>((_Val << 8) | (_Val >> 8));
+    } else {
+        return _byteswap_ushort(_Val);
+    }
+}
+
+constexpr uint32_t _Byteswap_ulong(const uint32_t _Val) noexcept {
+    if (std::_Is_constant_evaluated()) {
+        return (_Val << 24) | ((_Val << 8) & 0x00FF'0000) | ((_Val >> 8) & 0x0000'FF00) | (_Val >> 24);
+    } else {
+        return _byteswap_ulong(_Val);
+    }
+}
+
+constexpr uint64_t _Byteswap_uint64(const uint64_t _Val) noexcept {
+    if (std::_Is_constant_evaluated()) {
+        return (_Val << 56) | ((_Val << 40) & 0x00FF'0000'0000'0000) | ((_Val << 24) & 0x0000'FF00'0000'0000)
+             | ((_Val << 8) & 0x0000'00FF'0000'0000) | ((_Val >> 8) & 0x0000'0000'FF00'0000)
+             | ((_Val >> 24) & 0x0000'0000'00FF'0000) | ((_Val >> 40) & 0x0000'0000'0000'FF00) | (_Val >> 56);
+    } else {
+        return _byteswap_uint64(_Val);
+    }
+}
+
+template <class... T>
+constexpr bool _always_false_assert = false;
+
+template <typename Integer, typename = std::enable_if_t<std::is_integral<Integer>::value>>
+constexpr Integer byteswap(const Integer _Val) noexcept {
+    if constexpr (sizeof(Integer) == 1) {
+        return _Val;
+    } else if constexpr (sizeof(Integer) == 2) {
+        return static_cast<Integer>(_Byteswap_ushort(static_cast<uint16_t>(_Val)));
+    } else if constexpr (sizeof(Integer) == 4) {
+        return static_cast<Integer>(_Byteswap_ulong(static_cast<uint32_t>(_Val)));
+    } else if constexpr (sizeof(Integer) == 8) {
+        return static_cast<Integer>(_Byteswap_uint64(static_cast<uint64_t>(_Val)));
+    } else {
+        static_assert(_always_false_assert<Integer>, "Unexpected integer size");
+    }
+}

--- a/Pex/FileReader.cpp
+++ b/Pex/FileReader.cpp
@@ -102,14 +102,12 @@ void Pex::FileReader::readHeader(Pex::Header &header)
     // read magic as little endian to determine what endianness to set
     auto magic = getUint32(true);
 
-    // Little Endian = Fallout 4, Skyrim SE scripts stored in memory
-    // They appear to share the same PEX format, which differs significantly from
-    // the Skyrim PEX format.
-    // TODO: Verify this by dumping PEX in memory to disk.
+    // Little Endian = Fallout 4
+    // Has new PEX format with const, struct info, more debug info
     if (magic != LE_MAGIC_NUMBER)
     {
-        // Big Endian = Skyrim scripts stored on disk
-        // Has old Skyrim PEX format 
+        // Big Endian = Skyrim scripts
+        // Has old Skyrim PEX format
         if (magic != BE_MAGIC_NUMBER) {
             throw std::runtime_error("Invalid file magic");
         }
@@ -171,7 +169,7 @@ void Pex::FileReader::read(Pex::DebugInfo &debugInfo)
                 lineNumbers.push_back(getUint16());
             }
         }
-        // Skyrim scripts stored on disk do not have the following info
+        // Skyrim scripts do not have the following info
         if (m_endianness == BIG_ENDIAN){
             return;
         }
@@ -242,13 +240,13 @@ void Pex::FileReader::read(Pex::Objects &objects)
 
         object.setParentClassName(getStringIndex());
         object.setDocString(getStringIndex());
-        // Skyrim scripts stored on disk do not have this info 
+        // Skyrim scripts do not have this info 
         if (m_endianness == LITTLE_ENDIAN) {
             object.setConstFlag(getUint8());
         }
         object.setUserFlags(getUint32());
         object.setAutoStateName(getStringIndex());
-        // Skyrim scripts stored on disk do not have this info 
+        // Skyrim scripts do not have this info 
         if (m_endianness == LITTLE_ENDIAN) {
             read(object.getStructInfos());
         }
@@ -300,7 +298,7 @@ void Pex::FileReader::read(Pex::Variables &variables)
         variable.setUserFlags(getUint32());
 
         variable.setDefaultValue(getValue());
-        // Skyrim scripts stored on disk do not have this info 
+        // Skyrim scripts do not have this info 
         if (m_endianness == LITTLE_ENDIAN) {
             variable.setConstFlag(getUint8());
         }

--- a/Pex/FileReader.cpp
+++ b/Pex/FileReader.cpp
@@ -57,6 +57,7 @@ Pex::FileReader::~FileReader()
 void Pex::FileReader::read(Pex::Binary &binary)
 {
     readHeader(binary.getHeader());
+    binary.setGameType(m_endianness == BIG_ENDIAN ? Pex::Binary::GameType::SKYRIM : Pex::Binary::GameType::FALLOUT4);
     read(binary.getStringTable());
     m_StringTable = & binary.getStringTable();
     read(binary.getDebugInfo());

--- a/Pex/FileReader.cpp
+++ b/Pex/FileReader.cpp
@@ -1,8 +1,9 @@
 #include "FileReader.hpp"
+#include "ByteSwap.hpp"
+
 #include <iostream>
 #include <sstream>
 #include <iomanip>
-#include <type_traits>
 
 #include <cassert>
 
@@ -43,53 +44,6 @@ void Pex::FileReader::read(Pex::Binary &binary)
     read(binary.getDebugInfo());
     read(binary.getUserFlags());
     read(binary.getObjects());    
-}
-
-constexpr uint16_t _Byteswap_ushort(const uint16_t _Val) noexcept {
-    if (std::_Is_constant_evaluated()) {
-        return static_cast<unsigned short>((_Val << 8) | (_Val >> 8));
-    } else {
-        return _byteswap_ushort(_Val);
-    }
-}
-
-constexpr uint32_t _Byteswap_ulong(const uint32_t _Val) noexcept {
-    if (std::_Is_constant_evaluated()) {
-        return (_Val << 24) | ((_Val << 8) & 0x00FF'0000) | ((_Val >> 8) & 0x0000'FF00) | (_Val >> 24);
-    } else {
-        return _byteswap_ulong(_Val);
-    }
-}
-
-constexpr uint64_t _Byteswap_uint64(const uint64_t _Val) noexcept {
-    if (std::_Is_constant_evaluated()) {
-        return (_Val << 56) | ((_Val << 40) & 0x00FF'0000'0000'0000) | ((_Val << 24) & 0x0000'FF00'0000'0000)
-             | ((_Val << 8) & 0x0000'00FF'0000'0000) | ((_Val >> 8) & 0x0000'0000'FF00'0000)
-             | ((_Val >> 24) & 0x0000'0000'00FF'0000) | ((_Val >> 40) & 0x0000'0000'0000'FF00) | (_Val >> 56);
-    } else {
-        return _byteswap_uint64(_Val);
-    }
-}
-// template <typename Integer, typename = std::enable_if_t<std::is_integral<Integer>::value>>
-// constexpr uint64_t _get_sizeof_integer(Integer) noexcept {
-//     return constexpr (sizeof(Integer));
-// }
-template <class... T>
-constexpr bool always_false = false;
-
-template <typename Integer, typename = std::enable_if_t<std::is_integral<Integer>::value>>
-constexpr Integer byteswap(const Integer _Val) noexcept {
-    if constexpr (sizeof(Integer) == 1) {
-        return _Val;
-    } else if constexpr (sizeof(Integer) == 2) {
-        return static_cast<Integer>(_Byteswap_ushort(static_cast<uint16_t>(_Val)));
-    } else if constexpr (sizeof(Integer) == 4) {
-        return static_cast<Integer>(_Byteswap_ulong(static_cast<uint32_t>(_Val)));
-    } else if constexpr (sizeof(Integer) == 8) {
-        return static_cast<Integer>(_Byteswap_uint64(static_cast<uint64_t>(_Val)));
-    } else {
-        static_assert(always_false<Integer>, "Unexpected integer size");
-    }
 }
 
 /**

--- a/Pex/FileReader.cpp
+++ b/Pex/FileReader.cpp
@@ -564,37 +564,37 @@ std::string Pex::FileReader::getString()
  */
 Pex::Value Pex::FileReader::getValue()
 {
-    auto valueType = getUint8();
+    Pex::ValueType valueType = Pex::ValueType(getUint8());
     switch(valueType)
     {
-    case 0:
+    case Pex::ValueType::None:
         return Value();
         break;
-    case 1:
+    case Pex::ValueType::Identifier:
     {
         auto value = getStringIndex();
         return Value(value, true);
     }
         break;
-    case 2:
+    case Pex::ValueType::String:
     {
         auto value = getStringIndex();
         return Value(value);
     }
         break;
-    case 3:
+    case Pex::ValueType::Integer:
     {
         auto value = static_cast<std::int32_t>(getUint32());
         return Value(value);
     }
         break;
-    case 4:
+    case Pex::ValueType::Float:
     {
         auto value = getFloat();
         return Value(value);
     }
         break;
-    case 5:
+    case Pex::ValueType::Bool:
     {
         auto value = (getUint8() != 0);
         return Value(value);
@@ -602,7 +602,7 @@ Pex::Value Pex::FileReader::getValue()
         break;
     default:
         std::stringstream error;
-        error << "Invalid value type " << valueType;
+        error << "Invalid value type " << (uint8_t)valueType;
         throw std::runtime_error(error.str());
 
     }

--- a/Pex/FileReader.cpp
+++ b/Pex/FileReader.cpp
@@ -428,7 +428,7 @@ std::uint8_t Pex::FileReader::getUint8()
 
 /**
  * @brief Reads a 16 bit unsigned int from the file.
- * The int is store in the file coded in little endian.
+ * If file is big endian, byteswaps to little endian
  * @return a short read from the file.
  */
 std::uint16_t Pex::FileReader::getUint16()
@@ -447,7 +447,7 @@ std::uint16_t Pex::FileReader::getUint16()
 
 /**
  * @brief Reads a 32 bit unsigned int from the file.
- * The int is store in the file coded in little endian.
+ * If file is big endian, byteswaps to little endian
  * @return a long read from the file.
  */
 std::uint32_t Pex::FileReader::getUint32(bool le_override)
@@ -483,7 +483,7 @@ Pex::StringTable::Index Pex::FileReader::getStringIndex()
 
 /**
  * @brief Reads a 16 bit signed int from the file.
- * The int is store in the file coded in little endian.
+ * If file is big endian, byteswaps to little endian
  * @return a short read from the file.
  */
 std::int16_t Pex::FileReader::getInt16()
@@ -502,26 +502,26 @@ std::int16_t Pex::FileReader::getInt16()
 
 /**
  * @brief Reads a 32 bit float from the file.
- * The int is store in the file coded in little endian.
+ * If file is big endian, byteswaps to little endian
  * @return a float read from the file.
  */
 float Pex::FileReader::getFloat()
 {
-    uint32_t value; // for byteswapping, float is stored in x86 registers 40-bits wide
+    float value;
     m_iStream->read(reinterpret_cast<char*>(&value), sizeof(value));
     if(m_iStream->fail() || m_iStream->eof())
     {
         throw std::runtime_error("Error reading file");
     }
     if (m_endianness == BIG_ENDIAN){
-        value = byteswap(value);
+       value = byteswap_float(value);
     }
-    return static_cast<float>(value);
+    return value;
 }
 
 /**
  * @brief Reads a 64 bit time_t from the file.
- * The int is store in the file coded in little endian.
+ * If file is big endian, byteswaps to little endian
  * @return a time_t read from the file.
  */
 std::time_t Pex::FileReader::getTime()

--- a/Pex/FileReader.hpp
+++ b/Pex/FileReader.hpp
@@ -17,6 +17,7 @@ namespace Pex {
 class FileReader
 {
 public:
+    FileReader(std::istream *stream);
     FileReader(const std::string& fileName);
     ~FileReader();
 
@@ -60,6 +61,7 @@ protected:
 
 private:
     Endianness m_endianness;
-    std::ifstream m_File;
+    std::istream* m_iStream;
+    std::ifstream m_fileStream;
 };
 }

--- a/Pex/FileReader.hpp
+++ b/Pex/FileReader.hpp
@@ -21,6 +21,12 @@ public:
     ~FileReader();
 
     void read(Binary& binary);
+    enum Endianness{
+        BIG_ENDIAN,
+        LITTLE_ENDIAN
+    };
+    static constexpr std::uint32_t LE_MAGIC_NUMBER = 0xFA57C0DE;
+    static constexpr std::uint32_t BE_MAGIC_NUMBER = 0xDEC057FA;
 
 protected:
 
@@ -41,7 +47,7 @@ protected:
 
     std::uint8_t getUint8();
     std::uint16_t getUint16();
-    std::uint32_t getUint32();
+    std::uint32_t getUint32(bool le_override = false);
     StringTable::Index getStringIndex();
 
     std::int16_t getInt16();
@@ -53,6 +59,7 @@ protected:
     const StringTable* m_StringTable;
 
 private:
+    Endianness m_endianness;
     std::ifstream m_File;
 };
 }

--- a/Pex/Instruction.cpp
+++ b/Pex/Instruction.cpp
@@ -25,7 +25,7 @@ struct OpCodeInfo {
 /**
  * Opcode definition table
  */
-static const OpCodeInfo OPCODES[Pex::OpCode::MAX_OPCODE] = {
+static const OpCodeInfo OPCODES[int(Pex::OpCode::MAX_OPCODE)] = {
     {"nop", 0, false},
     {"iadd", 3, false},
     {"fadd", 3, false},

--- a/Pex/Instruction.hpp
+++ b/Pex/Instruction.hpp
@@ -58,8 +58,8 @@ enum class OpCode {
     ARRAY_REMOVELAST,
     ARRAY_REMOVE,
     ARRAY_CLEAR,
-	//New in Fallout 76
-	ARRAY_GETALLMATCHINGSTRUCTS,
+    //New in Fallout 76
+    ARRAY_GETALLMATCHINGSTRUCTS,
     MAX_OPCODE
 };
 

--- a/Pex/Object.cpp
+++ b/Pex/Object.cpp
@@ -8,6 +8,8 @@
  */
 Pex::Object::Object()
 {
+    // set to false at first due to on-disk Skyrim scripts not having this flag
+    m_ConstFlag = false; 
 }
 
 /**

--- a/Pex/StringTable.cpp
+++ b/Pex/StringTable.cpp
@@ -86,7 +86,7 @@ Pex::StringTable::Index Pex::StringTable::findIdentifier(const std::string &id) 
     }
     else
     {
-        return Index(this, it-begin());
+        return Index(this, uint16_t(it - begin()));
     }
 }
 

--- a/Pex/StringTable.hpp
+++ b/Pex/StringTable.hpp
@@ -77,7 +77,7 @@ protected:
 
 };
 }
-
+// TODO: Get this working with ostream&&, right now certain Index values are just being converted to string to work around this.
 inline std::ostream& operator << (std::ostream& stream, const Pex::StringTable::Index& index)
 {
     if(index.isValid())

--- a/Pex/StringTable.hpp
+++ b/Pex/StringTable.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <iostream>
 #include <cstdint>
+#include <sstream>
 
 namespace Pex {
 
@@ -77,8 +78,33 @@ protected:
 
 };
 }
+
+[[nodiscard]] inline std::string operator + (std::string str, const Pex::StringTable::Index& index)
+{
+    if(index.isValid())
+    {
+        return str + index.asString();
+    }
+    else
+    {
+        return str + "";
+    }
+}
 // TODO: Get this working with ostream&&, right now certain Index values are just being converted to string to work around this.
 inline std::ostream& operator << (std::ostream& stream, const Pex::StringTable::Index& index)
+{
+    if(index.isValid())
+    {
+        stream << index.asString();
+    }
+    else
+    {
+        stream << "*invalid*";
+    }
+    return stream;
+}
+
+inline std::ostringstream operator << (std::ostringstream stream, const Pex::StringTable::Index& index)
 {
     if(index.isValid())
     {

--- a/Pex/StringTable.hpp
+++ b/Pex/StringTable.hpp
@@ -90,7 +90,7 @@ protected:
         return str + "";
     }
 }
-// TODO: Get this working with ostream&&, right now certain Index values are just being converted to string to work around this.
+
 inline std::ostream& operator << (std::ostream& stream, const Pex::StringTable::Index& index)
 {
     if(index.isValid())

--- a/Pex/Value.cpp
+++ b/Pex/Value.cpp
@@ -238,8 +238,8 @@ bool Pex::Value::operator ==(const Pex::Value &rhs) const
 std::string Pex::Value::toString() const
 {
     std::ostringstream result;
-
-    switch(getType())
+    auto type = getType();
+    switch(type)
     {
         case Pex::ValueType::None:
         {
@@ -307,7 +307,7 @@ std::string Pex::Value::toString() const
             result << (getBool() ? "True" : "False");
             break;
         default:
-            result << "*error invalid value type*";
+            result << "*error invalid value type #" << (uint8_t) type << "*";
             break;
     }
 

--- a/Pex/Variable.cpp
+++ b/Pex/Variable.cpp
@@ -9,6 +9,8 @@
  */
 Pex::Variable::Variable()
 {
+    // set to false at first due to on-disk Skyrim scripts not having this flag
+    m_ConstFlag = false;
 }
 
 /**

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,5 +1,5 @@
 @PACKAGE_INIT@
 include(CMakeFindDependencyMacro)
 
-include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@.cmake")
-check_required_components("@PROJECT_NAME@")
+include("${CMAKE_CURRENT_LIST_DIR}/@CHAMPOLLION_TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@CHAMPOLLION_TARGETS_EXPORT_NAME@")

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+include(CMakeFindDependencyMacro)
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@")
+find_dependency(boost CONFIG)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -3,4 +3,3 @@ include(CMakeFindDependencyMacro)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@.cmake")
 check_required_components("@PROJECT_NAME@")
-find_dependency(boost CONFIG)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/master/docs/vcpkg.schema.json",
   "name": "champollion",
   "version-semver": "1.0.9",
   "port-version": 0,
@@ -7,32 +7,18 @@
   "homepage": "https://github.com/infomaniac50/Champollion",
   "license": "LGPL-3.0-only",
   "supports": "windows & x64",
-  "dependencies": [
-    "boost-system",
-    "boost-filesystem",
-    "boost-program-options",
-    "boost-format",
-    "boost-algorithm"
-  ],
+  "features": {
+    "standalone": {
+      "description": "Build as a standalone program",
+      "dependencies": [
+        "boost-program-options"
+      ]
+    }
+  },
+  "default-features": ["standalone"],
   "overrides": [
     {
-      "name": "boost-system",
-      "version": "1.80.0"
-    },
-    {
-      "name": "boost-filesystem",
-      "version": "1.80.0"
-    },
-    {
       "name": "boost-program-options",
-      "version": "1.80.0"
-    },
-    {
-      "name": "boost-format",
-      "version": "1.80.0"
-    },
-    {
-      "name": "boost-algorithm",
       "version": "1.80.0"
     }
   ],

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+  "name": "champollion",
+  "version-semver": "1.0.9",
+  "port-version": 0,
+  "description": "Papyrus Script Decompiler.",
+  "homepage": "https://github.com/infomaniac50/Champollion",
+  "license": "LGPL-3.0-only",
+  "supports": "windows & x64",
+  "dependencies": [
+    "boost-system",
+    "boost-filesystem",
+    "boost-program-options",
+    "boost-format",
+    "boost-algorithm"
+  ],
+  "overrides": [
+    {
+      "name": "boost-system",
+      "version": "1.80.0"
+    },
+    {
+      "name": "boost-filesystem",
+      "version": "1.80.0"
+    },
+    {
+      "name": "boost-program-options",
+      "version": "1.80.0"
+    },
+    {
+      "name": "boost-format",
+      "version": "1.80.0"
+    },
+    {
+      "name": "boost-algorithm",
+      "version": "1.80.0"
+    }
+  ],
+  "builtin-baseline": "4cb4a5c5ddcb9de0c83c85837ee6974c8333f032"
+}


### PR DESCRIPTION
This adds support for building on C++20 and adds a static library target to make this easily vcpkg-able and consumed downstream.

the thing that gave me the most trouble was the r/l-value changes in C++20; the tricks used to pipe stuff into ostream/ostringstream broke pretty badly. I attempted to fix it by using double references, but it often doesn’t work, so there’s a lot of "AsString()" scattered around the code now when writing. I’m not sure how to fix this properly, so if you have any ideas, let me know.

this also addresses the issues with the previous PR.