### PR TITLE
Fix-prop-float

### DIFF
--- a/Pex/Value.cpp
+++ b/Pex/Value.cpp
@@ -297,7 +297,7 @@ std::string Pex::Value::toString() const
             for (; i >= 0; i--) {
                 if (str[i] != '0') {
                     if (str[i] == '.')
-                        i--;
+                        i++;
                     break;
                 }
             }


### PR DESCRIPTION
float initalizers without `.0` at the end were rejected by PCompiler

Fixes #13 